### PR TITLE
fix(MT-805): correct podspec source URL to shield-ai-technology org

### DIFF
--- a/react-native-shield-fraud-plugin.podspec
+++ b/react-native-shield-fraud-plugin.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => "12.0" }
-  s.source       = { :git => "https://github.com/rajdeepak27/react-native-shield-fraud-plugin.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/shield-ai-technology/react-native-shield-fraud-plugin.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"
 


### PR DESCRIPTION
The source URL pointed to a personal fork (rajdeepak27) instead of the official organisation repository (shield-ai-technology). 