### PR TITLE
fix(MT-810): correct migration comment for LogLevel and Environment e…

### DIFF
--- a/android/src/main/java/com/shieldfraudplugin/ShieldFraudPluginModule.java
+++ b/android/src/main/java/com/shieldfraudplugin/ShieldFraudPluginModule.java
@@ -48,9 +48,9 @@ import java.util.Map;
  * 5. sendAttributes     : void return
  *                           →  shield.sendAttributesWithCallback (Result<String> callback)
  * 6. LogLevel enum      : Shield.LogLevel.VERBOSE/DEBUG/INFO/NONE
- *                           →  LogLevel.DEBUG / INFO / NONE  (VERBOSE removed)
+ *                           →  LogLevel.VERBOSE / DEBUG / INFO / NONE
  * 7. Environment enum   : String constants ENVIRONMENT_PROD / DEV / STAGING
- *                           →  Environment.PROD / DEV  (STAGING removed)
+ *                           →  Environment.PROD / DEV / STAGING
  *
  * Architecture segmentation
  * ─────────────────────────


### PR DESCRIPTION

The comment incorrectly stated that VERBOSE and STAGING were removed in the Shield SDK 2.x migration. Both values are still present and supported. Update the comment to accurately reflect the current enum members.