### PR TITLE
fix(MT-811): use nil instead of NULL for ObjC pointer checks

### DIFF
--- a/ios/ShieldFraudPlugin.mm
+++ b/ios/ShieldFraudPlugin.mm
@@ -37,13 +37,13 @@ RCT_EXPORT_METHOD(getLatestDeviceResult:(RCTResponseSenderBlock)successCallback
                   errorCallback:(RCTResponseSenderBlock)errorCallback)
 {
     NSDictionary<NSString *, id> *result = [[Shield shared] getLatestDeviceResult];
-    if (result != NULL) {
+    if (result != nil) {
         successCallback(@[result]);
         return;
     }
 
     NSError *error = [[Shield shared] getErrorResponse];
-    if (error != NULL) {
+    if (error != nil) {
         errorCallback(@[[error localizedDescription]]);
         return;
     }


### PR DESCRIPTION
NULL is a C null pointer constant. In Objective-C, nil is the correct idiom for checking object pointer nullability. Replace all NULL comparisons with nil in ShieldFraudPlugin.mm.