### PR TITLE
fix(MT-812): pin react-native dependency to 0.71.7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,8 +95,7 @@ rootProject.allprojects {
 dependencies {
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
-  //noinspection GradleDynamicVersion
-  implementation "com.facebook.react:react-native:+"
+  implementation "com.facebook.react:react-native:0.71.7"
 
   // Shield Fraud SDK 2.x — factory-based init, callback-based device intelligence
   implementation 'com.shield.android:shield-fraud:2.5.0'


### PR DESCRIPTION
Replace the dynamic '+' version wildcard with an explicit pinned version. Wildcards can silently pull in incompatible versions at build time.