### PR TITLE
fix(MT-813): set hasConstants to false in ShieldFraudPluginPackage

### DIFF
--- a/android/src/main/java/com/shieldfraudplugin/ShieldFraudPluginPackage.java
+++ b/android/src/main/java/com/shieldfraudplugin/ShieldFraudPluginPackage.java
@@ -67,7 +67,7 @@ public class ShieldFraudPluginPackage extends TurboReactPackage {
                     ShieldFraudPluginModule.NAME,  // className
                     false,                          // canOverrideExistingModule
                     false,                          // needsEagerInit
-                    true,                           // hasConstants
+                    false,                          // hasConstants
                     false,                          // isCxxModule
                     isTurboModule                   // isTurboModule
                 )


### PR DESCRIPTION
The module exposes no constants, so hasConstants must be false. Setting it to true causes unnecessary overhead on both architectures.