### PR TITLE
[MT-923] feat!: migrate iOS wrapper to ShieldFraud SDK 2.x

### DIFF
--- a/android/src/main/java/com/shieldfraudplugin/ShieldFraudPluginModule.java
+++ b/android/src/main/java/com/shieldfraudplugin/ShieldFraudPluginModule.java
@@ -44,7 +44,7 @@ import java.util.Map;
  * 1. Initialisation     : Shield.Builder  →  ShieldConfig + ShieldFactory
  * 2. Instance access    : Shield.getInstance()  →  stored `shield` member
  * 3. Session ID         : Shield.getInstance().getSessionId()  →  shield.getSessionId()
- * 4. Device results     : setDeviceResultStateListener(callback)
+ * 4. Device results     : manual readiness subscription
  *                           →  ShieldFactory.createShieldWithCallback (SHIELD Sentinel)
  * 5. sendAttributes     : void return
  *                           →  shield.sendAttributesWithCallback (Result<String> callback)
@@ -116,6 +116,7 @@ public class ShieldFraudPluginModule extends com.shieldfraudplugin.ShieldFraudPl
     public void initShield(
             String siteID,
             String secretKey,
+            @Nullable String partnerId,
             boolean isOptimizedListener,
             @Nullable ReadableMap blockedDialog,
             double logLevel,
@@ -133,6 +134,9 @@ public class ShieldFraudPluginModule extends com.shieldfraudplugin.ShieldFraudPl
         ShieldConfig config = new ShieldConfig(siteID, secretKey);
         config.setLogLevel(getLogLevelFromInt((int) logLevel));
         config.setEnvironment(getEnvironmentFromInt((int) environmentInfo));
+        if (partnerId != null) {
+            config.setPartnerId(partnerId);
+        }
 
         if (blockedDialog != null) {
             String title = blockedDialog.hasKey("title") ? blockedDialog.getString("title") : null;
@@ -147,8 +151,8 @@ public class ShieldFraudPluginModule extends com.shieldfraudplugin.ShieldFraudPl
 
         if (isOptimizedListener) {
             // SDK 2.x: createShieldWithCallback initialises + acts as the Sentinel.
-            // Unlike 1.x (which required a separate setDeviceResultStateListener() call
-            // on the SDK), 2.x fires this callback automatically when device intelligence
+            // Unlike 1.x (which required a separate readiness subscription),
+            // 2.x fires this callback automatically when device intelligence
             // is ready and on every subsequent risk-profile change.
             // The callback may arrive on a background thread — always post to main looper.
             shield = ShieldFactory.createShieldWithCallback(
@@ -159,7 +163,7 @@ public class ShieldFraudPluginModule extends com.shieldfraudplugin.ShieldFraudPl
                             DeviceIntelligence di =
                                     ((Result.Success<DeviceIntelligence>) result).getData();
                             JSONObject json = di != null ? di.getData() : null;
-                            emitEvent("success", json != null ? json.toString() : null);
+                            emitEvent("success", json != null ? toWritableMap(json) : null);
                         } else if (result instanceof Result.Failure) {
                             ShieldError error =
                                     ((Result.Failure<DeviceIntelligence>) result).getError();
@@ -184,23 +188,6 @@ public class ShieldFraudPluginModule extends com.shieldfraudplugin.ShieldFraudPl
         ShieldCrossPlatformParams params =
                 new ShieldCrossPlatformParams(crossPlatformName, crossPlatformVersion);
         ShieldCrossPlatformHelper.setCrossPlatformParameters(params);
-    }
-
-    // =========================================================================
-    // setDeviceResultStateListener — no-op stub (SDK 2.x)
-    //
-    // SDK 1.x required a manual subscription call + Handler.postDelayed workaround.
-    // SDK 2.x fires device result events automatically via createShieldWithCallback
-    // when isOptimizedListener == true — no subscription call needed.
-    //
-    // The method is kept as a no-op stub so the shared TypeScript codegen spec
-    // and iOS (which still calls the SDK method) remain unaffected.
-    // =========================================================================
-
-    @ReactMethod
-    public void setDeviceResultStateListener() {
-        // No-op on Android SDK 2.x — device result events are delivered
-        // automatically through the createShieldWithCallback Sentinel.
     }
 
     // =========================================================================
@@ -301,7 +288,11 @@ public class ShieldFraudPluginModule extends com.shieldfraudplugin.ShieldFraudPl
                 new android.os.Handler(android.os.Looper.getMainLooper()).post(() -> {
                     if (result instanceof Result.Success) {
                         JSONObject json = shield.getLatestDeviceResult();
-                        successCallback.invoke(json != null ? toWritableMap(json) : null);
+                        if (json != null) {
+                            successCallback.invoke(toWritableMap(json));
+                        } else {
+                            errorCallback.invoke("No device result available.");
+                        }
                     } else if (result instanceof Result.Failure) {
                         ShieldError error = ((Result.Failure<String>) result).getError();
                         errorCallback.invoke(error != null

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -14,8 +14,7 @@ const App = () => {
   useEffect(() => {
     const initializeShield = async () => {
       // ------------------------------------------------------------------
-      // Use callbacks for logging and live SDK events, and use isSDKready()
-      // as the single readiness gate for post-init work on both platforms.
+      // Use callbacks for logging and live SDK events.
       // ------------------------------------------------------------------
       const callbacks: ShieldCallback = {
         onSuccess: (data) => {
@@ -42,19 +41,15 @@ const App = () => {
 
       await ShieldFraud.initShield(config, callbacks);
 
-      // Use the same SDK-ready gate on Android and iOS.
-      ShieldFraud.isSDKready(async (isReady: boolean) => {
-        if (isReady) {
-          await runPostInitCalls();
-        } else {
-          console.log('[Shield] SDK is not ready');
-        }
-      });
+      if (ShieldFraud.isShieldInitialized()) {
+        await runPostInitCalls();
+      } else {
+        console.log('[Shield] SDK is not initialized');
+      }
     };
 
     // ------------------------------------------------------------------
-    // Post-init calls — same logic for both platforms, called from
-    // the shared isSDKready callback.
+    // Post-init calls — same logic for both platforms.
     // ------------------------------------------------------------------
     const runPostInitCalls = async () => {
       // Session ID

--- a/ios/ShieldFraudPlugin.h
+++ b/ios/ShieldFraudPlugin.h
@@ -5,20 +5,13 @@
 #import <React/RCTEventEmitter.h>
 #import "RNShieldFraudPluginSpec.h"
 
-// Forward-declare the protocol — the full definition is imported in the .mm file.
-// A forward declaration is sufficient for the @interface conformance declaration.
-@protocol DeviceShieldCallback;
-
-@interface ShieldFraudPlugin : RCTEventEmitter <NativeShieldFraudPluginSpec, DeviceShieldCallback>
+@interface ShieldFraudPlugin : RCTEventEmitter <NativeShieldFraudPluginSpec>
 #else
 // Old Architecture: standard bridge module + event emitter.
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
 
-// Forward-declare the protocol — full definition imported in the .mm file.
-@protocol DeviceShieldCallback;
-
-@interface ShieldFraudPlugin : RCTEventEmitter <RCTBridgeModule, DeviceShieldCallback>
+@interface ShieldFraudPlugin : RCTEventEmitter <RCTBridgeModule>
 #endif
 
 @end

--- a/ios/ShieldFraudPlugin.mm
+++ b/ios/ShieldFraudPlugin.mm
@@ -1,16 +1,15 @@
 #import "ShieldFraudPlugin.h"
 
-// Import the auto-generated Swift→ObjC header.
-// This exposes all Swift-exported types (Configuration, Shield, BlockedDialog,
-// LogLevel, Environment, ShieldCrossPlatformHelper, DeviceShieldCallback, …)
-// without requiring Clang module syntax (@import), which fails in Obj-C++ files
-// when C++ modules are not enabled (e.g. when the New Architecture codegen
-// headers are included and the file is compiled as Obj-C++).
+// ShieldFraud is Swift-based, but this source must remain Objective-C++ for
+// React Native's New Architecture. Importing the generated Objective-C header
+// avoids forcing -fcxx-modules on consumers that link the plugin statically.
 #import <ShieldFraud/ShieldFraud-Swift.h>
 
-@implementation ShieldFraudPlugin
+@interface ShieldFraudPlugin ()
+@property (nonatomic, strong) id<Shield> shield;
+@end
 
-static BOOL isShieldInitialized = NO;
+@implementation ShieldFraudPlugin
 
 RCT_EXPORT_MODULE();
 
@@ -36,40 +35,35 @@ RCT_EXPORT_METHOD(setCrossPlatformParameters:(NSString *)crossPlatformName
 RCT_EXPORT_METHOD(getLatestDeviceResult:(RCTResponseSenderBlock)successCallback
                   errorCallback:(RCTResponseSenderBlock)errorCallback)
 {
-    NSDictionary<NSString *, id> *result = [[Shield shared] getLatestDeviceResult];
-    if (result != nil) {
-        successCallback(@[result]);
+    if (self.shield == nil) {
+        errorCallback(@[@"Shield SDK is not initialized."]);
         return;
     }
 
-    NSError *error = [[Shield shared] getErrorResponse];
-    if (error != nil) {
-        errorCallback(@[[error localizedDescription]]);
+    DeviceIntelligence *deviceIntelligence = [self.shield getLatestDeviceResult];
+    if (deviceIntelligence != nil) {
+        successCallback(@[deviceIntelligence.data]);
         return;
     }
 
     errorCallback(@[@"No device result available yet."]);
 }
 
-// Subscribe to real-time device-result state changes
-RCT_EXPORT_METHOD(setDeviceResultStateListener)
-{
-    double delayInSeconds = 1.5;
-    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW,
-                                            (int64_t)(delayInSeconds * NSEC_PER_SEC));
-    dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
-        [[Shield shared] setDeviceResultStateListener:^{
-            [self sendEventWithName:@"device_result_state"
-                              body:@{@"status": @"isSDKReady"}];
-        }];
-    });
-}
-
 // Attach arbitrary screen-level attributes
 RCT_EXPORT_METHOD(sendAttributes:(NSString *)screenName
                   data:(NSDictionary *)data)
 {
-    [[Shield shared] sendAttributesWithScreenName:screenName data:data];
+    if (self.shield == nil) {
+        return;
+    }
+
+    [self.shield sendAttributesWithScreenName:screenName
+                                         data:[self stringAttributesFromDictionary:data]
+                                   completion:^(NSString *sessionId, ShieldError *error) {
+        if (error != nil) {
+            [self sendEventWithName:@"error" body:error.errorMessage];
+        }
+    }];
 }
 
 RCT_EXPORT_METHOD(sendAttributesWithCallback:(NSString *)screenName
@@ -77,60 +71,65 @@ RCT_EXPORT_METHOD(sendAttributesWithCallback:(NSString *)screenName
                   successCallback:(RCTResponseSenderBlock)successCallback
                   errorCallback:(RCTResponseSenderBlock)errorCallback)
 {
-    [[Shield shared] sendAttributesWithScreenName:screenName
-                                             data:data
-                                                :^(BOOL success, NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (success) {
-                successCallback(@[@(YES)]);
-                return;
-            }
+    if (self.shield == nil) {
+        errorCallback(@[@"Shield SDK is not initialized."]);
+        return;
+    }
 
-            NSString *errorMessage = error != nil
-                ? [error localizedDescription]
-                : @"Failed to send attributes.";
-            errorCallback(@[errorMessage]);
-        });
+    [self.shield sendAttributesWithScreenName:screenName
+                                         data:[self stringAttributesFromDictionary:data]
+                                   completion:^(NSString *sessionId, ShieldError *error) {
+        if (sessionId != nil) {
+            successCallback(@[@(YES)]);
+            return;
+        }
+
+        NSString *errorMessage = error != nil
+            ? error.errorMessage
+            : @"Failed to send attributes.";
+        errorCallback(@[errorMessage]);
     }];
 }
 
 // Trigger a device signature computation for a given screen name.
 // Pass userId to associate the result with a specific user.
-// The completionHandler fires when the SDK is done; results and errors
-// are read back from getLatestDeviceResult / getErrorResponse.
+// The 2.x completion returns a session ID or ShieldError. On success, return
+// the latest DeviceIntelligence payload to preserve the React Native API.
 RCT_EXPORT_METHOD(sendDeviceSignature:(NSString *)screenName
                   userId:(NSString * _Nullable)userId
                   successCallback:(RCTResponseSenderBlock)successCallback
                   errorCallback:(RCTResponseSenderBlock)errorCallback)
 {
+    if (self.shield == nil) {
+        errorCallback(@[@"Shield SDK is not initialized."]);
+        return;
+    }
+
     ShieldUserData *userData = [[ShieldUserData alloc]
                                     initWithScreenName:screenName
                                     userId:userId];
 
-    [[Shield shared] sendDeviceSignatureWithUserData:userData
-                                  completionHandler:^{
-        dispatch_async(dispatch_get_main_queue(), ^{
-            NSDictionary<NSString *, id> *deviceResult = [[Shield shared] getLatestDeviceResult];
-            if (deviceResult != nil) {
-                successCallback(@[deviceResult]);
-                return;
-            }
+    [self.shield sendDeviceSignatureWithUserData:userData
+                                      completion:^(NSString *sessionId, ShieldError *error) {
+        if (error != nil) {
+            errorCallback(@[error.errorMessage]);
+            return;
+        }
 
-            NSError *error = [[Shield shared] getErrorResponse];
-            if (error != nil) {
-                errorCallback(@[[error localizedDescription]]);
-                return;
-            }
+        DeviceIntelligence *deviceIntelligence = [self.shield getLatestDeviceResult];
+        if (sessionId != nil && deviceIntelligence != nil) {
+            successCallback(@[deviceIntelligence.data]);
+            return;
+        }
 
-            errorCallback(@[@"No device result available."]);
-        });
+        errorCallback(@[@"No device result available."]);
     }];
 }
 
 // RCTEventEmitter — declare the events this module can emit
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"success", @"error", @"device_result_state"];
+    return @[@"success", @"error"];
 }
 
 // RCTEventEmitter — required overrides (no-op wrappers keep the base class happy)
@@ -144,15 +143,95 @@ RCT_EXPORT_METHOD(sendDeviceSignature:(NSString *)screenName
     [super removeListeners:count];
 }
 
-// DeviceShieldCallback delegate — forwarded as JS events
-- (void)didErrorWithError:(NSError *)error
+// =============================================================================
+// MARK: - ShieldFraud 2.x helpers
+// =============================================================================
+
+- (void)initializeShieldWithSiteID:(NSString *)siteID
+                         secretKey:(NSString *)secretKey
+                         partnerId:(NSString * _Nullable)partnerId
+               optimizedListener:(BOOL)isOptimizedListener
+                    blockedDialog:(NSDictionary * _Nullable)blockedDialog
+                         logLevel:(NSInteger)logLevel
+                  environmentInfo:(NSInteger)environmentInfo
 {
-    [self sendEventWithName:@"error" body:[error localizedDescription]];
+    if (self.shield != nil) {
+        return;
+    }
+
+    ShieldConfig *config = [[ShieldConfig alloc] initWithSiteId:siteID
+                                                       secretKey:secretKey];
+    config.logLevel = [self logLevelFromInteger:logLevel];
+    config.environment = [self environmentFromInteger:environmentInfo];
+    if (partnerId != nil) {
+        config.partnerId = partnerId;
+    }
+
+    if (blockedDialog != nil) {
+        NSString *title = [blockedDialog objectForKey:@"title"];
+        NSString *body = [blockedDialog objectForKey:@"body"];
+        if (title != nil && body != nil) {
+            config.defaultBlockedDialog = [[BlockedDialog alloc] initWithTitle:title body:body];
+        }
+    }
+
+    self.shield = [ShieldFactory createShieldWithConfig:config];
+
+    if (isOptimizedListener) {
+        __weak ShieldFraudPlugin *weakSelf = self;
+        [self.shield onDeviceResultWithHandler:^(DeviceIntelligence *deviceIntelligence,
+                                                 ShieldError *error) {
+            ShieldFraudPlugin *strongSelf = weakSelf;
+            if (strongSelf == nil) {
+                return;
+            }
+
+            if (deviceIntelligence != nil) {
+                [strongSelf sendEventWithName:@"success" body:deviceIntelligence.data];
+                return;
+            }
+
+            if (error != nil) {
+                [strongSelf sendEventWithName:@"error" body:error.errorMessage];
+            }
+        }];
+    }
 }
 
-- (void)didSuccessWithResult:(NSDictionary<NSString *, id> *)result
+- (NSDictionary<NSString *, NSString *> *)stringAttributesFromDictionary:(NSDictionary *)data
 {
-    [self sendEventWithName:@"success" body:result];
+    NSMutableDictionary<NSString *, NSString *> *attributes = [NSMutableDictionary dictionary];
+    [data enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+        if ([key isKindOfClass:[NSString class]] && [value isKindOfClass:[NSString class]]) {
+            attributes[key] = value;
+        }
+    }];
+    return attributes;
+}
+
+- (LogLevel)logLevelFromInteger:(NSInteger)logLevel
+{
+    switch (logLevel) {
+        case 4:
+        case 3:
+            return LogLevelDebug;
+        case 2:
+            return LogLevelInfo;
+        default:
+            return LogLevelNone;
+    }
+}
+
+- (Environment)environmentFromInteger:(NSInteger)environmentInfo
+{
+    switch (environmentInfo) {
+        case 1:
+            return EnvironmentDev;
+        case 2:
+            return EnvironmentStag;
+        default:
+            return EnvironmentProd;
+    }
 }
 
 
@@ -181,6 +260,7 @@ RCT_EXPORT_METHOD(sendDeviceSignature:(NSString *)screenName
 
 - (void)initShield:(NSString *)siteID
          secretKey:(NSString *)secretKey
+         partnerId:(NSString * _Nullable)partnerId
 isOptimizedListener:(BOOL)isOptimizedListener
      blockedDialog:(NSDictionary * _Nullable)blockedDialog
           logLevel:(double)logLevel
@@ -189,38 +269,24 @@ blockScreenRecording:(BOOL)blockScreenRecording
            resolve:(RCTPromiseResolveBlock)resolve
             reject:(RCTPromiseRejectBlock)reject
 {
-    if (!isShieldInitialized) {
-        Configuration *config = [[Configuration alloc] initWithSiteId:siteID
-                                                            secretKey:secretKey];
-        if (isOptimizedListener) {
-            config.deviceShieldCallback = self;
-        }
-
-        if (blockedDialog != nil) {
-            NSString *title = [blockedDialog objectForKey:@"title"];
-            NSString *body  = [blockedDialog objectForKey:@"body"];
-            config.defaultBlockedDialog = [[BlockedDialog alloc] initWithTitle:title
-                                                                          body:body];
-        }
-
-        // JS numbers arrive as double; cast explicitly to Swift-bridged enum types.
-        config.logLevel    = (LogLevel)(NSInteger)logLevel;
-        config.environment = (Environment)(NSInteger)environmentInfo;
-
-        [Shield setUpWith:config];
-        isShieldInitialized = YES;
-    }
+    [self initializeShieldWithSiteID:siteID
+                           secretKey:secretKey
+                           partnerId:partnerId
+                  optimizedListener:isOptimizedListener
+                       blockedDialog:blockedDialog
+                            logLevel:(NSInteger)logLevel
+                     environmentInfo:(NSInteger)environmentInfo];
     resolve(nil);
 }
 
 - (NSString *)getSessionId
 {
-    return [[Shield shared] sessionId];
+    return self.shield != nil ? self.shield.sessionId : @"";
 }
 
 - (NSNumber *)isShieldInitialized
 {
-    return @(isShieldInitialized);
+    return @(self.shield != nil);
 }
 
 // Wires this Obj-C class into the JSI runtime.
@@ -243,51 +309,40 @@ blockScreenRecording:(BOOL)blockScreenRecording
 //
 // Key differences from New Arch:
 //   • initShield  — logLevel/environmentInfo are NSInteger (bridge coerces
-//                   from NSNumber); no resolve/reject (bridge wraps the void
-//                   return automatically).
+//                   from NSNumber); resolve/reject expose Promise<void> to JS.
 //   • getSessionId / isShieldInitialized — must use the blocking-synchronous
 //                   macro so the bridge returns the value to JS synchronously.
 // -----------------------------------------------------------------------------
 
 RCT_EXPORT_METHOD(initShield:(NSString *)siteID
                   secretKey:(NSString *)secretKey
+                  partnerId:(NSString * _Nullable)partnerId
                   isOptimizedListener:(BOOL)isOptimizedListener
                   blockedDialog:(NSDictionary *)blockedDialog
                   logLevel:(NSInteger)logLevel
                   environmentInfo:(NSInteger)environmentInfo
-                  blockScreenRecording:(BOOL)blockScreenRecording)
+                  blockScreenRecording:(BOOL)blockScreenRecording
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
 {
-    if (!isShieldInitialized) {
-        Configuration *config = [[Configuration alloc] initWithSiteId:siteID
-                                                            secretKey:secretKey];
-        if (isOptimizedListener) {
-            config.deviceShieldCallback = self;
-        }
-
-        if (blockedDialog != nil) {
-            NSString *title = [blockedDialog objectForKey:@"title"];
-            NSString *body  = [blockedDialog objectForKey:@"body"];
-            config.defaultBlockedDialog = [[BlockedDialog alloc] initWithTitle:title
-                                                                          body:body];
-        }
-
-        // Cast NSInteger to Swift-bridged enum types explicitly.
-        config.logLevel    = (LogLevel)logLevel;
-        config.environment = (Environment)environmentInfo;
-
-        [Shield setUpWith:config];
-        isShieldInitialized = YES;
-    }
+    [self initializeShieldWithSiteID:siteID
+                           secretKey:secretKey
+                           partnerId:partnerId
+                  optimizedListener:isOptimizedListener
+                       blockedDialog:blockedDialog
+                            logLevel:logLevel
+                     environmentInfo:environmentInfo];
+    resolve(nil);
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getSessionId)
 {
-    return [[Shield shared] sessionId];
+    return self.shield != nil ? self.shield.sessionId : @"";
 }
 
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(isShieldInitialized)
 {
-    return @(isShieldInitialized);
+    return @(self.shield != nil);
 }
 
 #endif  // RCT_NEW_ARCH_ENABLED

--- a/react-native-shield-fraud-plugin.podspec
+++ b/react-native-shield-fraud-plugin.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   # and replaces the legacy `s.dependency "React"` call.
   install_modules_dependencies(s)
 
-  s.dependency "ShieldFraud", ">= 2.0.0"
+  s.dependency "ShieldFraud", "2.0.0"
 end

--- a/react-native-shield-fraud-plugin.podspec
+++ b/react-native-shield-fraud-plugin.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   # and replaces the legacy `s.dependency "React"` call.
   install_modules_dependencies(s)
 
-  s.dependency "ShieldFraud", ">= 1.5.59"
+  s.dependency "ShieldFraud", ">= 2.0.0"
 end

--- a/react-native-shield-full-plugin.podspec
+++ b/react-native-shield-full-plugin.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   # and replaces the legacy `s.dependency "React"` call.
   install_modules_dependencies(s)
 
-  s.dependency "ShieldFraud", ">= 2.0.0"
+  s.dependency "ShieldFraud", "2.0.0"
 end

--- a/react-native-shield-full-plugin.podspec
+++ b/react-native-shield-full-plugin.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   # and replaces the legacy `s.dependency "React"` call.
   install_modules_dependencies(s)
 
-  s.dependency "ShieldFraud", ">= 1.5.58"
+  s.dependency "ShieldFraud", ">= 2.0.0"
 end

--- a/src/NativeShieldFraudPlugin.ts
+++ b/src/NativeShieldFraudPlugin.ts
@@ -13,6 +13,7 @@ export interface Spec extends TurboModule {
   initShield(
     siteID: string,
     secretKey: string,
+    partnerId: string | null,
     isOptimizedListener: boolean,
     blockedDialog: Object | null,
     logLevel: number,
@@ -38,11 +39,6 @@ export interface Spec extends TurboModule {
    * Returns whether the SDK has been initialized synchronously.
    */
   isShieldInitialized(): boolean;
-
-  /**
-   * Registers a listener for the device-result-ready state event.
-   */
-  setDeviceResultStateListener(): void;
 
   /**
    * Sends custom attributes for a given screen name.

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -9,12 +9,10 @@ const mockNativeModule = {
   sendAttributesWithCallback: jest.fn(),
   sendDeviceSignature: jest.fn(),
   setCrossPlatformParameters: jest.fn(),
-  setDeviceResultStateListener: jest.fn(),
 };
 
 const mockAddListener = jest.fn();
 const mockRemoveAllListeners = jest.fn();
-let mockPlatformOS = 'android';
 const fs = require('fs');
 const path = require('path');
 
@@ -27,9 +25,7 @@ jest.mock('react-native', () => ({
     ShieldFraudPlugin: mockNativeModule,
   },
   Platform: {
-    get OS() {
-      return mockPlatformOS;
-    },
+    OS: 'android',
   },
   TurboModuleRegistry: {
     get: jest.fn(() => mockNativeModule),
@@ -38,7 +34,7 @@ jest.mock('react-native', () => ({
 
 import ShieldFraud from '../index';
 
-describe('ShieldFraud.isSDKready', () => {
+describe('ShieldFraud native integration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (ShieldFraud as any).PlatformWrapper = mockNativeModule;
@@ -46,43 +42,14 @@ describe('ShieldFraud.isSDKready', () => {
       addListener: mockAddListener,
       removeAllListeners: mockRemoveAllListeners,
     };
-    mockPlatformOS = 'android';
   });
 
-  it('calls back with false on Android when the SDK is not initialized', async () => {
-    const callback = jest.fn();
-    const isShieldInitializedSpy = jest
-      .spyOn(ShieldFraud, 'isShieldInitialized')
-      .mockReturnValue(false);
-
-    await ShieldFraud.isSDKready(callback);
-
-    expect(isShieldInitializedSpy).toHaveBeenCalledTimes(1);
-    expect(callback).toHaveBeenCalledWith(false);
-    expect(mockAddListener).not.toHaveBeenCalled();
-    expect(
-      mockNativeModule.setDeviceResultStateListener
-    ).not.toHaveBeenCalled();
-
-    isShieldInitializedSpy.mockRestore();
-  });
-
-  it('calls back with true on Android after the SDK is initialized', async () => {
-    const callback = jest.fn();
-    const isShieldInitializedSpy = jest
-      .spyOn(ShieldFraud, 'isShieldInitialized')
-      .mockReturnValue(true);
-
-    await ShieldFraud.isSDKready(callback);
-
-    expect(isShieldInitializedSpy).toHaveBeenCalledTimes(1);
-    expect(callback).toHaveBeenCalledWith(true);
-    expect(mockAddListener).not.toHaveBeenCalled();
-    expect(
-      mockNativeModule.setDeviceResultStateListener
-    ).not.toHaveBeenCalled();
-
-    isShieldInitializedSpy.mockRestore();
+  it.each([
+    [{ siteID: '', secretKey: 'secret-key' }, 'siteId must not be empty'],
+    [{ siteID: 'site-id', secretKey: '' }, 'secretKey must not be empty'],
+  ])('rejects invalid credentials in JavaScript', async (config, message) => {
+    await expect(ShieldFraud.initShield(config)).rejects.toThrow(message);
+    expect(mockNativeModule.initShield).not.toHaveBeenCalled();
   });
 
   it('removes existing success and error subscriptions before registering new callback listeners', async () => {
@@ -108,6 +75,33 @@ describe('ShieldFraud.isSDKready', () => {
     expect(mockAddListener).toHaveBeenCalledTimes(4);
   });
 
+  it('registers optimized listeners before initialization and forwards partnerId', async () => {
+    mockAddListener.mockReturnValue({ remove: jest.fn() });
+
+    await ShieldFraud.initShield(
+      {
+        siteID: 'site-id',
+        secretKey: 'secret-key',
+        partnerId: 'partner-id',
+      },
+      { onSuccess: jest.fn(), onFailure: jest.fn() }
+    );
+
+    expect(mockNativeModule.initShield).toHaveBeenCalledWith(
+      'site-id',
+      'secret-key',
+      'partner-id',
+      true,
+      null,
+      1,
+      0,
+      false
+    );
+    expect(mockAddListener.mock.invocationCallOrder[0]!).toBeLessThan(
+      mockNativeModule.initShield.mock.invocationCallOrder[0]!
+    );
+  });
+
   it('exposes synchronous values for synchronous native state methods', () => {
     mockNativeModule.getSessionId.mockReturnValue('session-id');
     mockNativeModule.isShieldInitialized.mockReturnValue(true);
@@ -117,30 +111,6 @@ describe('ShieldFraud.isSDKready', () => {
 
     expect(sessionId).toBe('session-id');
     expect(isInitialized).toBe(true);
-  });
-
-  it('starts the iOS readiness listener without a fixed JavaScript delay', async () => {
-    mockPlatformOS = 'ios';
-    const callback = jest.fn();
-    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
-    const isShieldInitializedSpy = jest
-      .spyOn(ShieldFraud, 'isShieldInitialized')
-      .mockReturnValue(true);
-
-    await ShieldFraud.isSDKready(callback);
-
-    expect(isShieldInitializedSpy).toHaveBeenCalledTimes(1);
-    expect(mockAddListener).toHaveBeenCalledWith(
-      'device_result_state',
-      expect.any(Function)
-    );
-    expect(mockNativeModule.setDeviceResultStateListener).toHaveBeenCalledTimes(
-      1
-    );
-    expect(setTimeoutSpy).not.toHaveBeenCalled();
-
-    isShieldInitializedSpy.mockRestore();
-    setTimeoutSpy.mockRestore();
   });
 });
 
@@ -186,6 +156,37 @@ describe('Podspec metadata', () => {
       ':git => "https://github.com/shield-ai-technology/react-native-shield-fraud-plugin.git"'
     );
   });
+
+  it('requires ShieldFraud 2.0.0 or newer in both package variants', () => {
+    const fraudPodspec = fs.readFileSync(
+      path.join(__dirname, '../../react-native-shield-fraud-plugin.podspec'),
+      'utf8'
+    );
+    const fullPodspec = fs.readFileSync(
+      path.join(__dirname, '../../react-native-shield-full-plugin.podspec'),
+      'utf8'
+    );
+
+    expect(fraudPodspec).toContain('s.dependency "ShieldFraud", ">= 2.0.0"');
+    expect(fullPodspec).toContain('s.dependency "ShieldFraud", ">= 2.0.0"');
+  });
+
+  it('does not force C++ module flags on static-library consumers', () => {
+    const fraudPodspec = fs.readFileSync(
+      path.join(__dirname, '../../react-native-shield-fraud-plugin.podspec'),
+      'utf8'
+    );
+    const fullPodspec = fs.readFileSync(
+      path.join(__dirname, '../../react-native-shield-full-plugin.podspec'),
+      'utf8'
+    );
+
+    for (const podspec of [fraudPodspec, fullPodspec]) {
+      expect(podspec).not.toContain('CLANG_ENABLE_MODULES');
+      expect(podspec).not.toContain('OTHER_CPLUSPLUSFLAGS');
+      expect(podspec).not.toContain('-fcxx-modules');
+    }
+  });
 });
 
 describe('Android Gradle dependencies', () => {
@@ -228,5 +229,117 @@ describe('iOS object nil checks', () => {
     );
 
     expect(iosSource).not.toContain('!= NULL');
+  });
+});
+
+describe('iOS ShieldFraud 2.x migration', () => {
+  const iosSource = fs.readFileSync(
+    path.join(__dirname, '../../ios/ShieldFraudPlugin.mm'),
+    'utf8'
+  );
+  const iosHeader = fs.readFileSync(
+    path.join(__dirname, '../../ios/ShieldFraudPlugin.h'),
+    'utf8'
+  );
+  const androidSource = fs.readFileSync(
+    path.join(
+      __dirname,
+      '../../android/src/main/java/com/shieldfraudplugin/ShieldFraudPluginModule.java'
+    ),
+    'utf8'
+  );
+  const nativeSpec = fs.readFileSync(
+    path.join(__dirname, '../NativeShieldFraudPlugin.ts'),
+    'utf8'
+  );
+  const wrapperSource = fs.readFileSync(
+    path.join(__dirname, '../index.tsx'),
+    'utf8'
+  );
+
+  it('creates and retains a Shield instance through ShieldFactory', () => {
+    expect(iosSource).toContain(
+      '@property (nonatomic, strong) id<Shield> shield;'
+    );
+    expect(iosSource).toContain('[[ShieldConfig alloc] initWithSiteId:siteID');
+    expect(iosSource).toContain(
+      '[ShieldFactory createShieldWithConfig:config]'
+    );
+    expect(iosSource).not.toContain('[Shield setUpWith:config]');
+    expect(iosSource).not.toContain('[Shield shared]');
+  });
+
+  it('uses the Shield 2.x result and error types', () => {
+    expect(iosSource).toContain('#import <ShieldFraud/ShieldFraud-Swift.h>');
+    expect(iosSource).not.toContain('@import ShieldFraud;');
+    expect(iosSource).toContain('[self.shield onDeviceResultWithHandler:');
+    expect(iosSource).toContain('deviceIntelligence.data');
+    expect(iosSource).toContain('error.errorMessage');
+    expect(iosSource).not.toContain('getErrorResponse');
+    expect(iosHeader).not.toContain('DeviceShieldCallback');
+  });
+
+  it('forwards partnerId through both native ShieldConfig implementations', () => {
+    expect(nativeSpec).toContain('partnerId: string | null');
+    expect(iosSource).toContain('config.partnerId = partnerId;');
+    expect(androidSource).toContain('config.setPartnerId(partnerId);');
+  });
+
+  it('registers the iOS device-result handler only for optimized mode', () => {
+    const optimizedBlock = iosSource.slice(
+      iosSource.indexOf('if (isOptimizedListener) {'),
+      iosSource.indexOf('- (NSDictionary<NSString *, NSString *> *)')
+    );
+
+    expect(optimizedBlock).toContain('[self.shield onDeviceResultWithHandler:');
+    expect(iosSource.indexOf('if (isOptimizedListener) {')).toBeLessThan(
+      iosSource.indexOf('[self.shield onDeviceResultWithHandler:')
+    );
+  });
+
+  it('emits object payloads for optimized results on both platforms', () => {
+    expect(iosSource).toContain(
+      'sendEventWithName:@"success" body:deviceIntelligence.data'
+    );
+    expect(androidSource).toContain(
+      'emitEvent("success", json != null ? toWritableMap(json) : null);'
+    );
+    expect(androidSource).not.toContain(
+      'emitEvent("success", json != null ? json.toString() : null);'
+    );
+  });
+
+  it('reports the same missing device-signature result error on both platforms', () => {
+    expect(iosSource).toContain('@"No device result available."');
+    expect(androidSource).toContain(
+      'errorCallback.invoke("No device result available.");'
+    );
+    expect(androidSource).not.toContain(
+      'successCallback.invoke(json != null ? toWritableMap(json) : null);'
+    );
+  });
+
+  it('resolves initShield as a promise in both iOS architectures', () => {
+    expect(
+      iosSource.match(/resolve:\(RCTPromiseResolveBlock\)resolve/g)
+    ).toHaveLength(2);
+    expect(iosSource.match(/resolve\(nil\);/g)).toHaveLength(2);
+  });
+
+  it('does not emit the legacy iOS 1.5.x readiness event', () => {
+    expect(iosSource).not.toContain('@"isSDKReady"');
+    expect(iosSource).not.toContain('@"device_result_state"');
+  });
+
+  it('removes the obsolete device-result readiness listener API', () => {
+    expect(wrapperSource).not.toContain('isSDKready');
+    expect(iosSource).not.toContain('setDeviceResultStateListener');
+    expect(androidSource).not.toContain('setDeviceResultStateListener');
+    expect(nativeSpec).not.toContain('setDeviceResultStateListener');
+  });
+
+  it('does not configure excluded modules or debugKey options', () => {
+    expect(iosSource).not.toContain('config.modules');
+    expect(iosSource).not.toContain('config.debugKey');
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,7 @@ export enum EnvironmentInfo {
 export interface Config {
   siteID: string;
   secretKey: string;
+  partnerId?: string | null;
   blockedDialog?: {
     title: string;
     body: string;
@@ -73,7 +74,7 @@ export type ShieldCallback = {
 
 /**
  * The `ShieldFraud` class is a wrapper for the ShieldFraudPlugin native module in React Native.
- * It provides methods for initializing ShieldFraud, retrieving session ID, checking the SDK readiness,
+ * It provides methods for initializing ShieldFraud, retrieving session ID,
  * sending attributes, and getting the latest device result.
  */
 class ShieldFraud {
@@ -106,6 +107,14 @@ class ShieldFraud {
     config: Config,
     callbacks?: ShieldCallback
   ): Promise<void> {
+    if (!config.siteID) {
+      throw new Error('siteId must not be empty');
+    }
+
+    if (!config.secretKey) {
+      throw new Error('secretKey must not be empty');
+    }
+
     const isOptimizedListener = !!callbacks;
 
     // Set default values if logLevel is not provided
@@ -124,21 +133,23 @@ class ShieldFraud {
     const blockScreenRecording =
       Platform.OS === 'android' ? config.blockScreenRecording ?? false : false;
 
+    if (isOptimizedListener) {
+      // Register JS listeners before native initialization because ShieldFraud may
+      // deliver a cached device result immediately when its handler is registered.
+      ShieldFraud.listeners(callbacks);
+    }
+
     // Call the native method to initialize ShieldFraud with the provided configuration.
     await ShieldFraud.PlatformWrapper.initShield(
       config.siteID,
       config.secretKey,
+      config.partnerId ?? null,
       isOptimizedListener,
       config.blockedDialog ?? null,
       logLevel,
       environmentInfo,
       blockScreenRecording
     );
-
-    if (isOptimizedListener) {
-      // Set up listeners for success and error events if callbacks are provided.
-      ShieldFraud.listeners(callbacks);
-    }
   }
 
   /**
@@ -197,57 +208,6 @@ class ShieldFraud {
    */
   public static isShieldInitialized(): boolean {
     return ShieldFraud.PlatformWrapper.isShieldInitialized();
-  }
-
-  /**
-   * Checks if the ShieldFraud SDK is ready and invokes the provided callback
-   * with the readiness state.
-   *
-   * On Android, readiness is approximated by the native initialization state
-   * to preserve backward compatibility without reporting ready before init.
-   *
-   * @param callback - A callback function to be invoked with the readiness state.
-   *   - `isReady` (boolean): true when the SDK has produced a device result.
-   */
-  public static async isSDKready(
-    callback: (isReady: boolean) => void
-  ): Promise<void> {
-    if (Platform.OS === 'android') {
-      const isInitialized = await this.isShieldInitialized();
-      callback(isInitialized);
-      return;
-    }
-
-    try {
-      // Adding a timeout of 100 milliseconds
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      const isInitialized = await this.isShieldInitialized();
-
-      if (!isInitialized) {
-        console.log('Shield SDK not initialized:');
-        callback(false);
-        return;
-      }
-
-      const deviceResultListener = (event: { status: string }) => {
-        if (event.status === 'isSDKReady') {
-          ShieldFraud.eventEmitter.removeAllListeners('device_result_state');
-          callback(true);
-        }
-      };
-
-      ShieldFraud.eventEmitter.addListener(
-        'device_result_state',
-        deviceResultListener
-      );
-
-      // Trigger the SDK subscription — iOS 1.x requires this explicit call.
-      ShieldFraud.PlatformWrapper.setDeviceResultStateListener();
-    } catch (error) {
-      console.error('An error occurred:', error);
-      callback(false);
-    }
   }
 
   /**


### PR DESCRIPTION
- migrate iOS integration to ShieldConfig and ShieldFactory
- add partnerId support across both platforms
- align optimized device-result payloads and errors
- return a Promise from iOS initShield in both architectures
- remove legacy isSDKReady and device-result state listener APIs
- validate credentials in the JavaScript wrapper
- require ShieldFraud 2.0.0 or newer in both podspecs
- preserve static-library compatibility

BREAKING CHANGE: removes isSDKReady and requires ShieldFraud SDK 2.0.0+.